### PR TITLE
adds github workflow for testing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @privateip @kevsmith

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,27 @@
+---
+name: test
+on:
+  push:
+    branches: [ devel ]
+  pull_request:
+    branches: [ devel ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ 3.5, 3.6, 3.7, 3.8 ]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r test/requirements.txt
+
+      - name: run tests
+        run: |
+          pytest --cov='pureport' --cov-append -v test/
+          flake8 pureport test


### PR DESCRIPTION
This commit adds a Github workflow to run through the unit tests
when code is submitted as a PR.  This will replicated the same tests
that can be run locally with `make test`

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>