### PR TITLE
unify the tox and github action workflows

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,3 +1,14 @@
+# #########################################################################
+#
+# NOTE:
+# This workflow serves to run the unit tests on push and pull requrest.
+# The workflow is replicated in <root>/tox.ini to serve as a way
+# to run the same test worklow from a local development enviornment.  If
+# any changes are made here, the same changes need to be propogated to
+# tox.ini
+#
+# #########################################################################
+
 ---
 name: test
 on:
@@ -25,12 +36,12 @@ jobs:
       - name: link with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 pureport/ test/  --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          flake8 pureport/ test/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: test with pytest
         env:
           PUREPORT_API_KEY: ${{ secrets.PUREPORT_API_KEY }}
-          PUREPORT_API_SECRET: ${{ secrets.PUREPORT_API_SECRET }}    
+          PUREPORT_API_SECRET: ${{ secrets.PUREPORT_API_SECRET }}
         run: |
           pytest --cov='pureport' --cov-append -v test/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,8 +40,5 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 pureport/ test/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: test with pytest
-        env:
-          PUREPORT_API_KEY: ${{ secrets.PUREPORT_API_KEY }}
-          PUREPORT_API_SECRET: ${{ secrets.PUREPORT_API_SECRET }}
         run: |
           pytest --cov='pureport' --cov-append -v test/

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -6,6 +6,12 @@
 import os
 import re
 
+
+from ..utils import utils
+
+os.environ['PUREPORT_API_KEY'] = utils.random_string()
+os.environ['PUREPORT_API_SECRET'] = utils.random_string()
+
 from pureport import api
 
 

--- a/test/unit/test_query.py
+++ b/test/unit/test_query.py
@@ -3,11 +3,16 @@
 # Copyright (c) 2020, Pureport, Inc.
 # All Rights Reserved
 
+import os
+
 from collections import namedtuple
 
 import pytest
 
 from ..utils import utils
+
+os.environ['PUREPORT_API_KEY'] = utils.random_string()
+os.environ['PUREPORT_API_SECRET'] = utils.random_string()
 
 from pureport import query
 from pureport.exceptions import PureportError

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,20 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
+# ###########################################################################
+#
+# NOTE:
+# Tox is used as locally for executing the test cases using a matrix of 
+# different Python environments.  When code changes are pushed to the
+# main repo via pull request, the test cases are iterated using Github
+# Actions which DOES NOT use Tox.  It is import than any changes to how
+# Tox runs tests should be replicated in .github/workflows/test.yaml
+#
+# ###########################################################################
+
+
 [tox]
-envlist = clean, flake8, py36, py37, py38, report
+envlist = clean, flake8, py35, py36, py37, py38, report
 
 [testenv]
 deps =
@@ -15,17 +27,19 @@ setenv =
     PYTHONDONTWRITEBYTECODE = 1
     
 depends = 
-    {py36,py37,py38}: clean
+    {py35, py36, py37, py38}: clean
     report: py38
 
 commands =
     pytest --cov='pureport' --cov-append -v test/
 
 [testenv:report]
-skip_install = true
-deps = coverage
+deps = 
+    coverage 
+    flake8
 commands = 
     coverage report -m
+    flake8 pureport/ test/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 [testenv:clean]
 deps = coverage
@@ -34,7 +48,5 @@ commands = coverage erase
 
 [testenv:flake8]
 commands = 
-    flake8 pureport test
-
-[flake8]
-max-line-length = 120
+    # stop the build if there are Python syntax errors or undefined names
+    flake8 pureport/ test/ --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
This commit ensures that tox and github action workflows are performing
the same tests with the same tools.

Background

Currently this project uses tox for orchestrating tests from the local
development environment and uses Github actions to test from push and
pull requests.  It is important that both tools implement the same
set of tests with the same tools.

This commit unifies the two test orchestrators and adds notes to each
file to remind developers to keep them in sync.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>