### PR TITLE
update transforms function to_bool

### DIFF
--- a/pureport/transforms.py
+++ b/pureport/transforms.py
@@ -45,6 +45,24 @@ def to_bool(val):
     :return: a bool value
     :rtype: bool
     """
+    val = val.lower() if isinstance(val, str) else val
+
+    # coerce the value to a true int.  this will happen if the
+    # value came from the environment
+    if isinstance(val, str):
+        try:
+            val = int(val)
+        except ValueError:
+            pass
+
+    if isinstance(val, int):
+        val = val != 0
+    elif val in (True, 'true', '0'):
+        val = True
+    elif val in (False, 'false'):
+        val = False
+    elif isinstance(val, (list, dict, set, tuple)):
+        val = len(val) != 0
     return bool(val)
 
 

--- a/test/unit/test_transforms.py
+++ b/test/unit/test_transforms.py
@@ -23,9 +23,27 @@ def test_to_int_exc():
 
 
 def test_to_bool():
-    for item in (True, False, utils.random_int(), utils.random_string()):
+    for item in (True, 'TRUE', 'True', 1, 10, utils.random_string()):
         resp = transforms.to_bool(item)
-        assert isinstance(resp, bool)
+        assert resp is True, item
+
+    for item in (False, 'FALSE', 'False', 0, '', None):
+        resp = transforms.to_bool(item)
+        assert resp is False, item
+
+    for item in ({}, [], ()):
+        resp = transforms.to_bool(item)
+        assert resp is False, item
+
+    items = (
+        {utils.random_string(): utils.random_string()},
+        [utils.random_string()],
+        (utils.random_string,)
+    )
+
+    for item in items:
+        resp = transforms.to_bool(item)
+        assert resp is True, item
 
 
 def test_to_str():


### PR DESCRIPTION
This commit updates the logic regarding how a value is tranformed into a
boolean value.  The function will now evalute the provided value a
little deeper and attempt to property transform the value to a boolean.

The pseudo-code workflow is essential as follows:

```
1. convert the value to lower case if its a string
2. convert the value to a real int if its an int/string
3. if the value is an int and the int is 0 its true otherwise false
4. if the value is True or true return True
5. if the value is False or false return False
6. if the instance is a collection then set true of the len is 0
   otherwise false
7. default return the value passed through the builtin bool() function
```

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>