### PR TITLE
adds automake setting

### DIFF
--- a/pureport/api.py
+++ b/pureport/api.py
@@ -44,7 +44,6 @@ from functools import (
     update_wrapper,
 )
 
-
 from pureport.helpers import (
     get_api,
     get_value
@@ -55,7 +54,11 @@ from pureport.transforms import (
     to_snake_case
 )
 
-from pureport import models
+from pureport import (
+    models,
+    defaults
+)
+
 from pureport.session import Session
 from pureport.credentials import default
 from pureport.exceptions import PureportError
@@ -207,4 +210,5 @@ def make():
                 globals()[name] = func
 
 
-make()
+if defaults.automake is True:
+    make()

--- a/pureport/defaults.py
+++ b/pureport/defaults.py
@@ -124,6 +124,14 @@ LOGGING_LEVEL = config_item(
 )
 
 
+AUTOMAKE = config_item(
+    description="Automatically run make() for API bindings",
+    default=True,
+    transform=transforms.to_bool,
+    env="PUREPORT_AUTOMAKE"
+)
+
+
 def defaults():
     attrs = {}
     for item in globals():


### PR DESCRIPTION
This commit adds a new feature switch `automake` that allows control
over whether or not the api will automatically issue the `make()`
function to auto bind to the openapi spec.  This commit introduces a new
environment setting `PUREPORT_AUTOMAKE` which accepts a boolean value.

When the setting is True (default), the api will automatically load and
bind the openapi spec as a set of functions when the api module is
imported.

Whent he setting is False, the api will not automatically bind the
functions and the responsibility is on the implementor to call the
`make()` function progammatically

This commit depends on the successful merge of #3

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>