### PR TITLE
fixes an issue when generating bindings

### DIFF
--- a/pureport/api.py
+++ b/pureport/api.py
@@ -203,12 +203,12 @@ def make():
         for method, attrs in properties.items():
             if 'operationId' in attrs:
                 name = to_snake_case(attrs['operationId'])
-                func = partial(request, session=session, method=method, uri=uri)
+                func = partial(request, session, method, uri)
                 func.__doc__ = attrs.get('summary')
                 func.__name__ = name
                 log.debug('adding function {}'.format(name))
                 globals()[name] = func
 
 
-if defaults.automake is True:
+if defaults.automake_bindings is True:
     make()

--- a/pureport/defaults.py
+++ b/pureport/defaults.py
@@ -124,11 +124,11 @@ LOGGING_LEVEL = config_item(
 )
 
 
-AUTOMAKE = config_item(
+AUTOMAKE_BINDINGS = config_item(
     description="Automatically run make() for API bindings",
     default=True,
     transform=transforms.to_bool,
-    env="PUREPORT_AUTOMAKE"
+    env="PUREPORT_AUTOMAKE_BINDINGS"
 )
 
 


### PR DESCRIPTION
This commit solves an exception that gets raised when attempting to run
a bound function.  The exception complains about providing mutliple
values for the keyword `session`  This fix properly constructs the
partial function so as to not trample all over the session argument.

This commit also includes an update to the configuration setting for
automatically generating bindings.  The setting `AUTOMAKE` has been
refactored to `AUTOMAKE_BINDINGS` to better reflect its use.  The env
variable is now `PUREPORT_AUTOMAKE_BINDINGS`

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>