### PR TITLE
update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,7 @@ docs:
 	cd docs && make clean
 	cd docs && sphinx-apidoc ../pureport -o . -f
 	cd docs && PUREPORT_AUTOMAKE_BINDINGS=0 make html
+
+
+build: clean
+	python setup.py sdist bdist_wheel


### PR DESCRIPTION
This commit adds a new target to ```make``` for building a Python
distribution ready for upload.  The new target is ```make build``` which
extends ```clean``` and creates both a sdist and bdist wheel.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>