### PR TITLE
add support for query string parameters

### DIFF
--- a/pureport/session.py
+++ b/pureport/session.py
@@ -88,7 +88,7 @@ class Session(Request):
                 return True
         return False
 
-    def __call__(self, method, url, body=None, headers=None):
+    def __call__(self, method, url, body=None, headers=None, query=None):
         """Manages the sending and receiving of requests
 
         This method provides some additional capabilities built
@@ -111,6 +111,9 @@ class Session(Request):
             HTTP headers
         :type headers: dict
 
+        :param query: Key/value pairs used to construct the query string
+        :type query: dict
+
         :return: Instance of Response
         :rtype: :class:`pureport.transport.Response`
         """
@@ -132,7 +135,7 @@ class Session(Request):
 
         log.debug("sending request to {}".format(self.base_url))
         log.debug("body={}".format(body))
-        resp = super(Session, self).__call__(method, url, body, headers)
+        resp = super(Session, self).__call__(method, url, body, headers, query=query)
         log.debug("received valid response, returning to calling function")
         return resp
 
@@ -161,7 +164,7 @@ class Session(Request):
 
         self.authorization_expiration = time.time() + data['expires_in']
 
-    def get(self, url, body=None, headers=None):
+    def get(self, url, body=None, headers=None, query=None):
         """ HTTP GET method
 
         :param url: Fully qualified HTTP URL
@@ -173,12 +176,15 @@ class Session(Request):
         :param headers: Optional HTTP headers
         :type headers: dict
 
+        :param query: Optional HTTP query string
+        :type field: dict
+
         :return: HTTP Response object
         :rtype: :class:`pureport.transport.Response`
         """
-        return self.__call__('GET', url, body=body, headers=headers)
+        return self.__call__('GET', url, body=body, headers=headers, query=query)
 
-    def post(self, url, body=None, headers=None):
+    def post(self, url, body=None, headers=None, query=None):
         """ HTTP POST method
 
         :param url: Fully qualified HTTP URL
@@ -190,12 +196,15 @@ class Session(Request):
         :param headers: Optional HTTP headers
         :type headers: dict
 
+        :param query: Optional HTTP query string
+        :type field: dict
+
         :return: HTTP Response object
         :rtype: :class:`pureport.transport.Response`
         """
-        return self.__call__('POST', url, body=body, headers=headers)
+        return self.__call__('POST', url, body=body, headers=headers, query=query)
 
-    def put(self, url, body=None, headers=None):
+    def put(self, url, body=None, headers=None, query=None):
         """ HTTP PUT method
 
         :param url: Fully qualified HTTP URL
@@ -207,12 +216,15 @@ class Session(Request):
         :param headers: Optional HTTP headers
         :type headers: dict
 
+        :param query: Optional HTTP query string
+        :type field: dict
+
         :return: HTTP Response object
         :rtype: :class:`pureport.transport.Response`
         """
-        return self.__call__('PUT', url, body=body, headers=headers)
+        return self.__call__('PUT', url, body=body, headers=headers, query=query)
 
-    def delete(self, url, body=None, headers=None):
+    def delete(self, url, body=None, headers=None, query=None):
         """ HTTP DELETE method
 
         :param url: Fully qualified HTTP URL
@@ -224,10 +236,13 @@ class Session(Request):
         :param headers: Optional HTTP headers
         :type headers: dict
 
+        :param query: Optional HTTP query string
+        :type query: dict
+
         :return: HTTP Response object
         :rtype: :class:`pureport.transport.Response`
         """
-        return self.__call__('DELETE', url, body=body, headers=headers)
+        return self.__call__('DELETE', url, body=body, headers=headers, query=query)
 
     def options(self, url, body=None, headers=None):
         """ HTTP OPTIONS method

--- a/pureport/transport.py
+++ b/pureport/transport.py
@@ -114,7 +114,7 @@ class Request(object):
             "read_timeout={})".format(connect_timeout, read_timeout)
         )
 
-    def __call__(self, method, url, body=None, headers=None):
+    def __call__(self, method, url, body=None, headers=None, query=None):
         """Sends the HTTP request
 
         :param method: HTTP method
@@ -129,6 +129,9 @@ class Request(object):
         :param headers: HTTP headers
         :type headers: dict
 
+        :param query: HTTP query string
+        :type query: dict
+
         :return: HTTP Response
         :rtype: :class:`Response`
         """
@@ -136,7 +139,7 @@ class Request(object):
             log.debug("Sending request to remote server")
             log.debug("method={}, url={}".format(method, url))
             log.debug("headers={}".format(','.join(headers or {})))
-            resp = self.http.request(method, url, body=body, headers=headers)
+            resp = self.http.request(method, url, body=body, headers=headers, fields=query)
         except (HTTPError, TimeoutError) as exc:
             message = getattr(exc, 'message', None) or \
                     defaults.generic_transport_error_message

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -17,7 +17,7 @@ SentinelResponse = namedtuple('SentinelResponse', ('status', 'data', 'headers', 
 response = partial(SentinelResponse, status=200, data=None, headers=None, json=None)
 
 
-def generate_response(method, url, body=None, headers=None):
+def generate_response(method, url, body=None, headers=None, query=None):
     if url == '/openapi.json':
         basepath = os.path.dirname(__file__)
         content = open(os.path.join(basepath, '../openapi.json')).read()

--- a/test/unit/test_transport.py
+++ b/test/unit/test_transport.py
@@ -31,7 +31,7 @@ def test_default(mock_request):
     req = pureport.transport.Request()
     url = utils.random_string()
     resp = req('GET', url)
-    mock_request.assert_called_with('GET', url, body=None, headers=None)
+    mock_request.assert_called_with('GET', url, body=None, headers=None, fields=None)
     assert resp.status == 200
     assert resp.data is None
     assert resp.json is None
@@ -44,7 +44,7 @@ def test_methods_with_body(mock_request):
     data = {utils.random_string(): utils.random_string()}
     url = utils.random_string()
     resp = req('GET', url, data)
-    mock_request.assert_called_with('GET', url, body=data, headers=None)
+    mock_request.assert_called_with('GET', url, body=data, headers=None, fields=None)
     assert resp.status == 200
     assert resp.data is None
     assert resp.json is None
@@ -58,7 +58,7 @@ def test_methods_return_data(mock_request):
     data = {utils.random_string(): utils.random_string()}
     url = utils.random_string()
     resp = req('GET', url, data)
-    mock_request.assert_called_with('GET', url, body=data, headers=None)
+    mock_request.assert_called_with('GET', url, body=data, headers=None, fields=None)
     assert resp.status == 200
     assert resp.data == response_data
     assert resp.json is None
@@ -72,7 +72,7 @@ def test_methods_return_data_and_json(mock_request):
     data = {utils.random_string(): utils.random_string()}
     url = utils.random_string()
     resp = req('GET', url, body=data)
-    mock_request.assert_called_with('GET', url, body=data, headers=None)
+    mock_request.assert_called_with('GET', url, body=data, headers=None, fields=None)
     assert resp.status == 200
     assert resp.data == response_data
     assert resp.json == json.loads(response_data)


### PR DESCRIPTION
This commit adds support for passing query string parameters to the api
call.  Prior to this change, there was no way to pass query strings.
This introduces a new keyword argument query` to the transport
`__call__` method for handling the query strings.  The value should be a
python dict object.  The keyword has also been extended to the `Session`
instance.

This commit also includes support for passing query stirng details from
the autogenerated api functions.  For functions that support query
parameters per the spec, the function will accept a new keywork argument
`query` as a python dict and pass the query information to the request
object.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>