### PR TITLE
update describe function()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+0.3.0 / 2020-09-10
+==================
+
+  * Added describe() function to recreate entire model schema
+ 
+
 0.2.0 / 2020-09-07
 ==================
 
   * Add support for passing query string to API call
   * Add support for accepting query parameters for auto generated functions
+
 
 0.1.0 / 2020-09-04
 ==================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -69,6 +69,34 @@ The return value from the bound function `find_all_accounts()` will return an
 instance of a Model object. The next section will discuss models.
 
 
+Disabling bindings
+------------------
+
+Bindings are created by default the first time `pureport.api` is imported into
+your application.  Sometimes, this is not the desired behavior.  You can
+disable the bindings from being automatically created by setting the following
+environment variable
+
+    .. code-block:: bash
+
+        export PUREPORT_AUTOMAKE_BINDINGS=0
+
+When the `PUREPORT_AUTOMATKE_BINDINGS` is set to False, the bindings are not
+automatically generated at import time.  You can still manually call `make()`
+to create bindings.
+
+    .. code-block:: python
+
+        >>> from pureport import api
+        >>> api.find_all_accounts()
+        Traceback (most recent call last):
+          File "<stdin>", line 1, in <module>
+        AttributeError: module 'pureport.api' has no attribute 'find_all_accounts'
+        >>> api.make()
+        >>> api.find_all_accounts()
+        [<pureport.models.Account object at 0x7fc167b535e0>, <pureport.models.Account object at 0x7fc167b53760>]
+
+
 Using models
 ------------
 
@@ -270,4 +298,221 @@ like the example below.
         <pureport.models.Network object at 0x7fc393cb04f0>
 
 
+Introspecting with describe()
+-----------------------------
 
+The `describe()` function provides a way to introspect a model to generate
+the entire model's schema.  It handles creating the full schema including any
+parents as well as reference links.  The `describe()` function provides a quick
+way to understand a model without having to comb thorugh the OpenAPI
+specification.
+
+For example, let's assume we want to review the `Network` model schema.
+
+    .. code-block:: python
+
+        >>> import json
+        >>> from pureport import api
+        >>> schema = api.models.describe('Network'), indent=4, sort_keys=True)
+        >>> print(json.dumps(schema))
+        {
+            "account": {
+                "items": {
+                    "href": {
+                        "readonly": false,
+                        "required": true,
+                        "type": "string"
+                    },
+                    "id": {
+                        "readonly": false,
+                        "required": false,
+                        "type": "string"
+                    },
+                    "title": {
+                        "readonly": false,
+                        "required": false,
+                        "type": "string"
+                    }
+                },
+                "readonly": false,
+                "ref": "Link",
+                "required": false,
+                "type": "object"
+            },
+            "description": {
+                "readonly": false,
+                "required": false,
+                "type": "string"
+            },
+            "href": {
+                "readonly": true,
+                "required": false,
+                "type": "string"
+            },
+            "id": {
+                "readonly": false,
+                "required": false,
+                "type": "string"
+            },
+            "name": {
+                "readonly": false,
+                "required": true,
+                "type": "string"
+            },
+            "os_primary_controller_id": {
+                "readonly": true,
+                "required": false,
+                "type": "string"
+            },
+            "os_private_network_id": {
+                "readonly": true,
+                "required": false,
+                "type": "string"
+            },
+            "os_project_id": {
+                "readonly": true,
+                "required": false,
+                "type": "string"
+            },
+            "os_secondary_controller_id": {
+                "readonly": true,
+                "required": false,
+                "type": "string"
+            },
+            "primary_controller_external_id": {
+                "readonly": true,
+                "required": false,
+                "type": "string"
+            },
+            "secondary_controller_external_id": {
+                "readonly": true,
+                "required": false,
+                "type": "string"
+            },
+            "state": {
+                "enum": [
+                    "PENDING",
+                    "PROVISIONING",
+                    "PENDING_CONTROLLERS",
+                    "DELETING_CONTROLLERS",
+                    "PROVISIONING_CONTROLLERS",
+                    "ACTIVE",
+                    "DELETING",
+                    "DELETED",
+                    "ERROR"
+                ],
+                "readonly": false,
+                "ref": "NetworkState",
+                "required": false,
+                "type": "string"
+            },
+            "tags": {
+                "readonly": false,
+                "required": false,
+                "type": "object"
+            },
+            "test_network": {
+                "readonly": false,
+                "required": false,
+                "type": "boolean"
+            }
+        }
+
+
+The output above provides the entire schema for the `Network` model.  The
+`describe()` function also provides some filters to allow you to return only
+properties that are read/write and/or fields that are required.
+
+For instance, let's assume we want to only see the fields of the `Network`
+model that are read/write.  We can set the `readwrite` keyword argument to
+True.
+
+    .. code-block:: python
+
+        >>> schema = api.models.describe('Network', readwrite=True), indent=4, sort_keys=True)
+        >>> print(json.dumps(schema, indent=4, sort_keys=True))
+        {
+            "account": {
+                "items": {
+                    "href": {
+                    "readonly": false,
+                    "required": true,
+                    "type": "string"
+                    },
+                    "id": {
+                    "readonly": false,
+                    "required": false,
+                    "type": "string"
+                    },
+                    "title": {
+                    "readonly": false,
+                    "required": false,
+                    "type": "string"
+                    }
+                },
+                "readonly": false,
+                "ref": "Link",
+                "required": false,
+                "type": "object"
+            },
+            "description": {
+                "readonly": false,
+                "required": false,
+                "type": "string"
+            },
+            "id": {
+                "readonly": false,
+                "required": false,
+                "type": "string"
+            },
+            "name": {
+                "readonly": false,
+                "required": true,
+                "type": "string"
+            },
+            "state": {
+                "enum": [
+                    "PENDING",
+                    "PROVISIONING",
+                    "PENDING_CONTROLLERS",
+                    "DELETING_CONTROLLERS",
+                    "PROVISIONING_CONTROLLERS",
+                    "ACTIVE",
+                    "DELETING",
+                    "DELETED",
+                    "ERROR"
+                ],
+                "readonly": false,
+                "ref": "NetworkState",
+                "required": false,
+                "type": "string"
+            },
+            "tags": {
+                "readonly": false,
+                "required": false,
+                "type": "object"
+            },
+            "test_network": {
+                "readonly": false,
+                "required": false,
+                "type": "boolean"
+            }
+        }
+
+We can also return just the required fields by setting the functions `required`
+keyword argument to True.
+
+    .. code-block:: python
+
+        >>> schema = api.models.describe('Network', readwrite=True, required=True), indent=4, sort_keys=True)
+        >>> print(json.dumps(schema))
+        {
+            "name": {
+                "readonly": false,
+                "required": true,
+                "type": "string"
+            }
+        }
+
+The `describe()` function helps simply working with the Pureport models by
+providing a convenient way to introspect model schema.

--- a/pureport/models.py
+++ b/pureport/models.py
@@ -89,9 +89,8 @@ def describe(model, readwrite=False, required=False):
 
     if isinstance(schema, Enum):
         properties.update({
-            'type': 'Enum',
-            'items': schema.type,
-            'values': schema.values
+            'type': schema.type,
+            'enum': schema.values,
         })
         return properties
 
@@ -102,12 +101,23 @@ def describe(model, readwrite=False, required=False):
                     if '$ref' in schema.properties[item]:
                         ref = schema.properties[item]['$ref'].split('/')[-1]
                         value = describe(ref, readwrite, required)
-                        value.update({
-                            'required': item in schema.required,
-                            'readonly': schema.properties[item].get('readOnly', False),
-                            'ref': ref
-                        })
-                        properties[item] = value
+
+                        if 'enum' in value:
+                            value.update({
+                                'required': item in schema.required,
+                                'readonly': schema.properties[item].get('readOnly', False),
+                                'ref': ref
+                            })
+                            properties[item] = value
+
+                        else:
+                            properties[item] = {
+                                'items': value,
+                                'required': item in schema.required,
+                                'readonly': schema.properties[item].get('readOnly', False),
+                                'ref': ref,
+                                'type': schema.properties[item].get('type', 'object')
+                            }
                     else:
                         properties[item] = {
                             'type': schema.properties[item].get('type', 'string'),


### PR DESCRIPTION
This commit updates the returned data structure from the describe()
function.  It makes subtle changes to how a Enum is described.  It now
changes `values` to `enum`, drops the items key and changes the `type`
key to reflect the property type.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>