### PR TITLE
fixes #16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ==================
 
   * Added describe() function to recreate entire model schema
+  * Fixed documentation formating issue (#16)
  
 
 0.2.0 / 2020-09-07

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,11 +7,11 @@ This page provides details on different ways Ansible can be installed.
 Installing from PyPI
 ~~~~~~~~~~~~~~~~~~~~
 
-The Pureport Python SDK can be installed using `pip <https://pip.pypa.io>`_::
+The Pureport Python SDK can be installed using `pip <https://pip.pypa.io>`_:
 
     .. code-block:: bash
 
-    $ pip install pureport-python
+        $ pip install pureport-python
 
 
 Installing from Source
@@ -19,9 +19,11 @@ Installing from Source
 
 The Pureport Fabric SDK can alternatively be installed directly from source for
 the latest code.  You can obtain the latest source code from `Github
-<https://github.com/pureport/pureport-python>`_::
+<https://github.com/pureport/pureport-python>`_:
+
 
     .. code-block:: bash
 
-    $ git clone https://github.com/pureport/pureport-python
-    $ python setup.py install
+        $ git clone https://github.com/pureport/pureport-python
+        $ python setup.py install
+


### PR DESCRIPTION
This commit addresses the issue raised in #16.  It removes an extra `:`
at the end of the line that was preventing the documentation from
building correclty.  The fix will be included in the next release.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>