### PR TITLE
integrates changelog into docs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,8 @@
-0.3.0 / 2020-09-10
-==================
+Changelog
+=========
+
+v0.3.0 / (in progress)
+----------------------
 
   * Added describe() function to recreate entire model schema
   * Fixed documentation formating issue (#16)
@@ -9,16 +12,16 @@
   * Automatically inject session account id into function arguments
   * Remove `pureport.defaults.automake_bindings` setting
   * Add automake_bindings keyword argument to session init
- 
 
-0.2.0 / 2020-09-07
-==================
+
+v0.2.0 / 2020-09-07
+-------------------
 
   * Add support for passing query string to API call
   * Add support for accepting query parameters for auto generated functions
 
 
-0.1.0 / 2020-09-04
-==================
+v0.1.0 / 2020-09-04
+-------------------
 
   * Initial release of python-pureport

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ https://console.pureport.com.
    session
    bindings
    defaults
+   changelog
 
 
 Indices and tables


### PR DESCRIPTION
This commit moves the CHANGELOG.md file from the root of the project
into docs/changelog.rst.  Any updates to the change log for a release
should be documented in that file.  This resolves #14

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>