### PR TITLE
fixes issue with automatically adding accountId

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 v0.4.0 / (in progress)
 ----------------------
 
+  * fixes error with auto inserting discovered accountId argument
+
 
 v0.3.0 / 2020-09-13
 -------------------


### PR DESCRIPTION
This commit addresses a bug where the accountId argument is not
automatically added to the function call resulting in an exception.
With this fix, the accountId now works as expected.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>