### PR TITLE
updates status code check for POST operation

### DIFF
--- a/pureport/functions.py
+++ b/pureport/functions.py
@@ -104,7 +104,7 @@ update_wrapper(get, send_request)
 put = partial(send_request, method='PUT', status_codes=(200,))
 update_wrapper(put, send_request)
 
-post = partial(send_request, method='POST', status_codes=(201,))
+post = partial(send_request, method='POST', status_codes=(200, 201,))
 update_wrapper(post, send_request)
 
 delete = partial(send_request, method='DELETE', status_codes=(204,))


### PR DESCRIPTION
This commit adds status code 200 to the list of status codes that get
checked when a POST operation is called.  There are some endpoints such
as stop, start, and respawn for gateways that will return a 200 status
code.  Prior to this change, the POST operation would complete
succesfully but the client would error due to the 200 code not being
considered a valid return code for success

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>