### PR TITLE
converts array items to appropriate type

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ v0.4.0 / (in progress)
 ----------------------
 
   * fixes error with auto inserting discovered accountId argument
+  * converts list items to appropriate typed classes
 
 
 v0.3.0 / 2020-09-13


### PR DESCRIPTION
This commit check the type required for elements in an array and builds
the appropriate typed object.  Prior to this change, list items were
just accepted, now they are loaded as a type.  If the entries in the
list do not meet the objects requirements, an exception is generated

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>