### PR TITLE
update model setters to use transforms

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ v0.4.0 / (in progress)
 
   * fixes error with auto inserting discovered accountId argument
   * converts list items to appropriate typed classes
+  * model setters now use transforms to set descriptors
+  * transforms updated to include min and max values for int and str
 
 
 v0.3.0 / 2020-09-13

--- a/pureport/transforms.py
+++ b/pureport/transforms.py
@@ -9,12 +9,14 @@ transforming data into a native Python data type.
 """
 from __future__ import absolute_import
 
+import sys
 import re
 
+from pureport.exceptions import PureportError
 from pureport.exceptions import PureportTransformError
 
 
-def to_int(val):
+def to_int(val, minimum=None, maximum=None):
     """Convert value to type int
 
     :param val: any valid object
@@ -26,7 +28,12 @@ def to_int(val):
     :raises: :class:`pureport.exceptions.PureportTransformError`
     """
     try:
-        return int(val)
+        minimum = minimum or 0
+        maximum = maximum or sys.maxsize
+        val = int(val)
+        if minimum > val > maximum:
+            raise PureportError("integer is outside of defined range")
+        return val
     except ValueError as exc:
         raise PureportTransformError(
             "unable to convert value to type `int`",
@@ -66,7 +73,7 @@ def to_bool(val):
     return bool(val)
 
 
-def to_str(val):
+def to_str(val, minlen=None, maxlen=None):
     """Convert value to type str
 
     :param val: any valid object
@@ -75,7 +82,15 @@ def to_str(val):
     :return: a str value
     :rtype: str
     """
-    return str(val)
+    val = str(val)
+
+    minlen = minlen or 0
+    maxlen = maxlen or sys.maxsize
+
+    if minlen > len(val) > maxlen:
+        raise PureportError("string has invalid length")
+
+    return val
 
 
 def to_float(val):


### PR DESCRIPTION
This commit changes how descriptors are set. It now calls the
appropriate transform function from `pureport.transforms` instead of
using the native Python function directly.

This change also updates the transforms functions `to_int` and `to_str`
to allow minimum and maximum values.  If the provided value violates
either minimum or maximum a PureportError exception is raised.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>