### PR TITLE
adds serialize() method to Array class

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ v0.4.0 / (in progress)
   * converts list items to appropriate typed classes
   * model setters now use transforms to set descriptors
   * transforms updated to include min and max values for int and str
+  * adds serialize() function to Array class
+
 
 
 v0.3.0 / 2020-09-13

--- a/pureport/models.py
+++ b/pureport/models.py
@@ -325,6 +325,9 @@ class Array(object):
     def remove(self, value):
         self._items.remove(value)
 
+    def serialize(self):
+        return [o.serialize() for o in self._items]
+
 
 def _get_property(self, name):
     if name in self.__dict__:
@@ -474,7 +477,7 @@ class Base(object):
         """
         obj = {}
         for key, value in self.__dict__.items():
-            if isinstance(value, Base):
+            if isinstance(value, (Base, Array)):
                 obj[key] = value.serialize()
             elif isinstance(value, list) and len(value):
                 if isinstance(value[0], Base):


### PR DESCRIPTION
This commit adds a `serialize()` method to the Array class to serialize
all items in the Array.  The method returns a list of serialized
objects.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>