### PR TITLE
adds new update() method to models Base

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ v0.4.0 / (in progress)
   * model setters now use transforms to set descriptors
   * transforms updated to include min and max values for int and str
   * adds serialize() function to Array class
+  * adds update() method to models Base class
 
 
 

--- a/pureport/models.py
+++ b/pureport/models.py
@@ -464,6 +464,15 @@ class Base(object):
             except AttributeError:
                 self.__dict__[key] = value
 
+    def update(self, data):
+        """Update the model with new values
+        """
+        for key, value in data.items():
+            if isinstance(getattr(self, key), Base):
+                model = describe(self.__class__.__name__)
+                value = load(model[key]['ref'], value)
+            setattr(self, key, value)
+
     def serialize(self):
         """Serialize the object to a dict
 


### PR DESCRIPTION
This commit adds a new instance method to the models Base class that
allows the instance to be updated from a dictionary.  The provided
dictionary is recursed and property objects are automatically created.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>