### PR TITLE
fixes issue with child model loading

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ v0.4.0 / (in progress)
   * transforms updated to include min and max values for int and str
   * adds serialize() function to Array class
   * adds update() method to models Base class
-
+  * fixes issue with child models failing to load properly
 
 
 v0.3.0 / 2020-09-13

--- a/pureport/models.py
+++ b/pureport/models.py
@@ -199,6 +199,9 @@ def load(clsname, data):
             schema = globals().get(clsname)._schema
             properties.update(schema.properties)
 
+    for key, value in schema.parents.items():
+        properties.update(value.properties)
+
     for key, value in properties.items():
         if data.get(key) is not None:
             if '$ref' in value:


### PR DESCRIPTION
This commit fixes an issue that would cause a child model to error when
trying to load it.  The error occured because the load function didn't
update the properties from the parent. This change fixes that problem
and child models now load properly

Signed-off-by: sprygada <peter.sprygada@pureport.com>