### PR TITLE
fix up how requests are handled

### DIFF
--- a/pureport/functions.py
+++ b/pureport/functions.py
@@ -199,7 +199,6 @@ def request(session, method, uri, *args, **kwargs):
                 log.debug("automatically injecting account_id argument")
                 variables['account_id'] = session.account_id
             else:
-                import q; q.d()
                 raise PureportError("missing required argument: {}".format(p))
 
     func = globals().get(method)

--- a/pureport/transport.py
+++ b/pureport/transport.py
@@ -127,7 +127,18 @@ class Request(object):
             log.debug("Sending request to remote server")
             log.debug("method={}, url={}".format(method, url))
             log.debug("headers={}".format(','.join(headers or {})))
-            resp = self.http.request(method, url, body=body, headers=headers, fields=query)
+
+            if body is not None:
+                if isinstance(body, dict):
+                    body = json.dumps(body)
+                resp = self.http.urlopen(method, url, body=body, headers=headers)
+
+            elif query is not None:
+                resp = self.http.request_encode_url(method, url, fields=query, headers=headers)
+
+            else:
+                resp = self.http.request(method, url, headers=headers)
+
         except (HTTPError) as exc:
             message = getattr(exc, 'message', None) or \
                     defaults.generic_transport_error_message

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -66,7 +66,7 @@ def test_convenience_methods(mock_request):
         assert resp.json is None
 
 
-@patch.object(urllib3, 'request')
+@patch.object(urllib3, 'urlopen')
 def test_call_converts_dict_to_json(mock_request):
     mock_request.return_value = response()
 
@@ -87,7 +87,7 @@ def test_call_converts_dict_to_json(mock_request):
     assert resp.json is None
 
 
-@patch.object(urllib3, 'request')
+@patch.object(urllib3, 'urlopen')
 def test_call_with_authorize(mock_request):
     auth_response = {
         'access_token': utils.random_string(),

--- a/test/unit/test_transport.py
+++ b/test/unit/test_transport.py
@@ -31,26 +31,40 @@ def test_default(mock_request):
     req = pureport.transport.Request()
     url = utils.random_string()
     resp = req('GET', url)
-    mock_request.assert_called_with('GET', url, body=None, headers=None, fields=None)
+    mock_request.assert_called_with('GET', url, headers=None)
     assert resp.status == 200
     assert resp.data is None
     assert resp.json is None
 
 
-@patch.object(urllib3, 'request')
+@patch.object(urllib3, 'urlopen')
 def test_methods_with_body(mock_request):
     mock_request.return_value = response()
     req = pureport.transport.Request()
     data = {utils.random_string(): utils.random_string()}
     url = utils.random_string()
     resp = req('GET', url, data)
-    mock_request.assert_called_with('GET', url, body=data, headers=None, fields=None)
+    mock_request.assert_called_with('GET', url, body=json.dumps(data), headers=None)
     assert resp.status == 200
     assert resp.data is None
     assert resp.json is None
 
 
-@patch.object(urllib3, 'request')
+@patch.object(urllib3, 'request_encode_url')
+def test_methods_with_body(mock_request):
+    mock_request.return_value = response()
+    req = pureport.transport.Request()
+    data = {utils.random_string(): utils.random_string()}
+    url = utils.random_string()
+    resp = req('GET', url, query=data)
+    mock_request.assert_called_with('GET', url, fields=data, headers=None)
+    assert resp.status == 200
+    assert resp.data is None
+    assert resp.json is None
+
+
+
+@patch.object(urllib3, 'urlopen')
 def test_methods_return_data(mock_request):
     response_data = str((utils.random_string(), utils.random_string(), utils.random_string()))
     mock_request.return_value = response(data=response_data)
@@ -58,13 +72,13 @@ def test_methods_return_data(mock_request):
     data = {utils.random_string(): utils.random_string()}
     url = utils.random_string()
     resp = req('GET', url, data)
-    mock_request.assert_called_with('GET', url, body=data, headers=None, fields=None)
+    mock_request.assert_called_with('GET', url, body=json.dumps(data), headers=None)
     assert resp.status == 200
     assert resp.data == response_data
     assert resp.json is None
 
 
-@patch.object(urllib3, 'request')
+@patch.object(urllib3, 'urlopen')
 def test_methods_return_data_and_json(mock_request):
     response_data = json.dumps({utils.random_string(): utils.random_string()})
     mock_request.return_value = response(data=response_data)
@@ -72,7 +86,7 @@ def test_methods_return_data_and_json(mock_request):
     data = {utils.random_string(): utils.random_string()}
     url = utils.random_string()
     resp = req('GET', url, body=data)
-    mock_request.assert_called_with('GET', url, body=data, headers=None, fields=None)
+    mock_request.assert_called_with('GET', url, body=json.dumps(data), headers=None)
     assert resp.status == 200
     assert resp.data == response_data
     assert resp.json == json.loads(response_data)


### PR DESCRIPTION
This commit fixes an issue with how requests are handled when calling
the appropriate function from ullib3.  With this change, there is more
control given to the session instance to determine how fields are
handled between body and query string.  This commit also adresses a
probem that would surface if both body and query string were passed as
kwargs.

This commit also removes a lingering debug command from the functions
code.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>