### PR TITLE
fix up linting warnings

### DIFF
--- a/pureport/transport.py
+++ b/pureport/transport.py
@@ -22,7 +22,6 @@ import logging
 import urllib3
 
 from urllib3.exceptions import HTTPError
-from urllib3.exceptions import TimeoutError
 
 from pureport import defaults
 from pureport.exceptions import PureportTransportError

--- a/test/unit/test_transport.py
+++ b/test/unit/test_transport.py
@@ -51,7 +51,7 @@ def test_methods_with_body(mock_request):
 
 
 @patch.object(urllib3, 'request_encode_url')
-def test_methods_with_body(mock_request):
+def test_methods_with_query(mock_request):
     mock_request.return_value = response()
     req = pureport.transport.Request()
     data = {utils.random_string(): utils.random_string()}
@@ -61,7 +61,6 @@ def test_methods_with_body(mock_request):
     assert resp.status == 200
     assert resp.data is None
     assert resp.json is None
-
 
 
 @patch.object(urllib3, 'urlopen')


### PR DESCRIPTION
This commit provides fixes for warnings generated by flake8.  This
commit makes no changes to the code paths or logic.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>